### PR TITLE
Hide filmstrip nav on mobile, add mobile footer with prev/next nav

### DIFF
--- a/src/components/DayNav.astro
+++ b/src/components/DayNav.astro
@@ -345,4 +345,10 @@ const nextDay = days.find(d => d.day === currentDay + 1);
     border-radius: 2px;
     padding: 0 3px;
   }
+
+  @media (max-width: 768px) {
+    .day-nav {
+      display: none;
+    }
+  }
 </style>

--- a/src/pages/days/[day].astro
+++ b/src/pages/days/[day].astro
@@ -594,6 +594,117 @@ const heroPhoto = mapExt ? `/images/days/${day.day}/map.${mapExt}` : null;
     font-size: 0.9rem;
     color: var(--textMuted);
   }
+
+  /* ─── MOBILE FOOTER ──────────────────────────────────────────────────────── */
+  .mobile-footer {
+    display: none;
+  }
+
+  @media (max-width: 768px) {
+    .mobile-footer {
+      display: block;
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      z-index: 100;
+      background: color-mix(in srgb, var(--bgDeep, #060f1a) 92%, transparent);
+      backdrop-filter: blur(16px) saturate(1.4);
+      -webkit-backdrop-filter: blur(16px) saturate(1.4);
+      border-top: 1px solid var(--border, rgba(255,255,255,0.08));
+    }
+
+    body {
+      padding-bottom: calc(64px + 24px);
+    }
+
+    .mobile-footer-nav {
+      display: flex;
+      align-items: stretch;
+      height: 64px;
+    }
+
+    .mobile-footer-link {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0 1rem;
+      color: var(--textMuted, #8ab4cc);
+      text-decoration: none;
+      transition: background 0.15s, color 0.15s;
+      min-width: 0;
+    }
+
+    .mobile-footer-link:active {
+      background: rgba(255,255,255,0.05);
+      color: var(--accent, #7ebcd6);
+    }
+
+    .mobile-footer-link svg {
+      flex-shrink: 0;
+      width: 18px;
+      height: 18px;
+      opacity: 0.6;
+    }
+
+    .mobile-footer-link.next {
+      justify-content: flex-end;
+      text-align: right;
+    }
+
+    .mobile-footer-link-inner {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      min-width: 0;
+    }
+
+    .mobile-footer-dir {
+      font-family: 'Space Mono', monospace;
+      font-size: 0.6rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--accent, #7ebcd6);
+    }
+
+    .mobile-footer-cities {
+      font-size: 0.7rem;
+      font-family: 'Raleway', sans-serif;
+      font-weight: 500;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .mobile-footer-home {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 3px;
+      padding: 0 1.25rem;
+      color: var(--textMuted, #8ab4cc);
+      text-decoration: none;
+      border-left: 1px solid var(--border, rgba(255,255,255,0.08));
+      border-right: 1px solid var(--border, rgba(255,255,255,0.08));
+      flex-shrink: 0;
+      transition: background 0.15s, color 0.15s;
+    }
+
+    .mobile-footer-home:active {
+      background: rgba(255,255,255,0.05);
+      color: var(--accent, #7ebcd6);
+    }
+
+    .mobile-footer-home span {
+      font-family: 'Space Mono', monospace;
+      font-size: 0.5rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      opacity: 0.6;
+    }
+  }
 </style>
 
 <!-- ─── HERO ─────────────────────────────────────────────────────────────── -->
@@ -773,6 +884,52 @@ const heroPhoto = mapExt ? `/images/days/${day.day}/map.${mapExt}` : null;
 
 <!-- ─── FILMSTRIP NAV ───────────────────────────────────────────────────────── -->
 <DayNav currentDay={day.day} />
+
+<!-- ─── MOBILE FOOTER (shown on mobile, hidden on desktop) ──────────────────── -->
+<footer class="mobile-footer">
+  <div class="mobile-footer-nav">
+    {prevDay ? (
+      <a href={`/days/${prevDay.slug}`} class="mobile-footer-link prev">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="15,18 9,12 15,6"/></svg>
+        <span class="mobile-footer-link-inner">
+          <span class="mobile-footer-dir">Day {prevDay.day}</span>
+          <span class="mobile-footer-cities">{prevDay.fromShort} → {prevDay.toShort}</span>
+        </span>
+      </a>
+    ) : (
+      <div class="mobile-footer-link prev" style="opacity:0.3; pointer-events:none;">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="15,18 9,12 15,6"/></svg>
+        <span class="mobile-footer-link-inner">
+          <span class="mobile-footer-dir">Start</span>
+          <span class="mobile-footer-cities">Philadelphia</span>
+        </span>
+      </div>
+    )}
+
+    <a href="/" class="mobile-footer-home" aria-label="All days">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true" width="18" height="18"><circle cx="12" cy="12" r="9"/><line x1="12" y1="8" x2="12" y2="16"/><line x1="8" y1="12" x2="16" y2="12"/></svg>
+      <span>All Days</span>
+    </a>
+
+    {nextDay ? (
+      <a href={`/days/${nextDay.slug}`} class="mobile-footer-link next">
+        <span class="mobile-footer-link-inner">
+          <span class="mobile-footer-dir">Day {nextDay.day}</span>
+          <span class="mobile-footer-cities">{nextDay.fromShort} → {nextDay.toShort}</span>
+        </span>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="9,18 15,12 9,6"/></svg>
+      </a>
+    ) : (
+      <div class="mobile-footer-link next" style="opacity:0.3; pointer-events:none;">
+        <span class="mobile-footer-link-inner">
+          <span class="mobile-footer-dir">End</span>
+          <span class="mobile-footer-cities">California</span>
+        </span>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="9,18 15,12 9,6"/></svg>
+      </div>
+    )}
+  </div>
+</footer>
 
 {day.gpxUrl && (
   <>


### PR DESCRIPTION
On screens ≤768px, the fixed DayNav filmstrip is hidden (display:none preserved
in DOM). A new mobile-only footer takes its place: fixed to the bottom, shows
prev/next day links with city names and a centered home link.

https://claude.ai/code/session_01JHhvpYKWKtHVsLW2fNYXnX